### PR TITLE
Command line option to set maximum request body size. Default=100kb

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,7 +3,10 @@ var express = require('express'),
     bodyParser = require('body-parser'),
     app = express();
 
-app.use(bodyParser.json());
+var myLimit = typeof(process.argv[2]) != 'undefined' ? process.argv[2] : '100kb';
+console.log('Using limit: ', myLimit);
+
+app.use(bodyParser.json({limit: myLimit}));
 
 app.all('*', function (req, res, next) {
 


### PR DESCRIPTION
Added support for a command line option to set the bodyParser upload limit.
The default is '100kb' (as per the bodyParser docs).
I have been using this as I'm uploading large(r) zip files to Salesforce using their tooling API. Without this I run into logs such as [this stackoverlfow one](http://stackoverflow.com/questions/19917401/node-js-express-request-entity-too-large) 

Let me know if you'd like anything from me.