### PR TITLE
Fix for issue #3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # CORS Proxy
 
-This simple Node.js-based proxy allows your JavaScript application to call services that are hosted on a different domain and that don't support [CORS](http://en.wikipedia.org/wiki/Cross-origin_resource_sharing). 
+This simple Node.js-based proxy allows your JavaScript application to call services that are hosted on a different domain and that don't support [CORS](http://en.wikipedia.org/wiki/Cross-origin_resource_sharing).
 
-Because the proxy is itself CORS-enabled, your application and the proxy don't have to be hosted on the same 
+Because the proxy is itself CORS-enabled, your application and the proxy don't have to be hosted on the same
 domain.
 
 This proxy was tested with the Salesforce.com REST API, but it should work with other services as well.
@@ -18,13 +18,13 @@ There are different options to get your own instance of the CORS proxy up and ru
 1. Install a local version
     - Clone this repository
     - Install the server dependencies
-    
+
         ```
         npm install
         ```
-    
+
     - Start the server
-         
+
          ```
          node server
          ```
@@ -33,18 +33,18 @@ There are different options to get your own instance of the CORS proxy up and ru
 
 When making an API call using JavaScript (using XMLHTTPRequest, $.ajax, etc):
 
-1. Substitute the actual service URL with the Proxy URL 
+1. Substitute the actual service URL with the Proxy URL
 
 1. Set the request method, query parameters, and body as usual
 
-1. Set the actual service URL in a header named 'Target-Endpoint'
+1. Set the actual service URL in a header named 'Target-URL'
 
 1. Send the request as usual
 
 
 ## CORS Headers
 
-The proxy allows **all** origins, methods, and headers. You probably want to lock this down in a production 
+The proxy allows **all** origins, methods, and headers. You probably want to lock this down in a production
 environment.
 
 
@@ -52,7 +52,7 @@ environment.
 
 The proxy currently passes the "Authorization" header to the target endpoint. You can modify the proxy to pass
  additional headers (or all of them).
- 
+
 
 ## Other Implementations
 

--- a/server.js
+++ b/server.js
@@ -21,7 +21,7 @@ app.all('*', function (req, res, next) {
     } else {
         var targetURL = req.header('Target-URL');
         if (!targetURL) {
-            res.send(500, { error: 'There is no Target-Endpoint header in the request' });
+            res.send(500, { error: 'There is no Target-URL header in the request' });
             return;
         }
         request({ url: targetURL + req.url, method: req.method, json: req.body, headers: {'Authorization': req.header('Authorization')} },


### PR DESCRIPTION
The documentation and the returned 500 error refer to `Target-Endpoint` header while in the code `Target-URL` is retrived